### PR TITLE
Suggestion of a different approach to types

### DIFF
--- a/System/Console/ANSI/Color.hs
+++ b/System/Console/ANSI/Color.hs
@@ -2,50 +2,59 @@
 module System.Console.ANSI.Color
   (
   -- | 8-bit to 24-bit color conversion
-    color8To24
+    xterm256ToSRGB
   -- | Utility functions
   , clamp
-  , color8CodeToEither
   , closest4bitsANSIColor
+  , closestXterm256Color
+  , color8CodeToXterm256
+  , colorToCode
+  , xterm256ColorToCode
     ) where
 
 
-import qualified Data.Colour.SRGB.Linear as SRGBLin(rgb, Colour)
-import qualified Data.Colour.SRGB as SRGB (RGB (..), toSRGB, Colour)
+import Data.Colour.SRGB (Colour, RGB (..), sRGB, toSRGB)
 
 import Data.Word (Word8)
 import Data.Colour.Names (black, blue, cyan, green, grey, lime, magenta, maroon,
                           navy, olive, purple, red, silver, teal, white, yellow)
 
 import Data.List (minimumBy, (!!))
+import Data.Maybe (fromJust)
 
 import System.Console.ANSI.Types
 
--- | Returns a color, in the linear sRGB colorspace, whose components are the components
---  of an 8-bit ANSI color.
+-- | Returns a color, in the sRGB colorspace, whose components are the
+-- components of an 8-bit ANSI color.
 -- For each color component, we first clamp the value to its admissible range
 -- defined in https://en.wikipedia.org/wiki/ANSI_escape_code#Colors:
 --  - 0-5 for 8-bit rgb
 --  - 0-23 for 8-bit grayscale
 -- Then we apply the xterm mapping (the mapped value is in range [0..255]).
 -- Finally we interpret the xterm-mapped values as components of a color
--- in linear srgb colorspace (we divide by 255 to express the value as a floating point in range [0 1]).
-color8To24 :: Color8 -> SRGBLin.Colour Float
-color8To24 (RGB8Color r' g' b') =
-  let mapping = (\v -> v/255.0) . fromIntegral . xtermMapRGB8bitComponent . (\v -> clamp v 0 5) :: Word8 -> Float
-      r = mapping r'
-      g = mapping g'
-      b = mapping b'
-  in  SRGBLin.rgb r g b
-color8To24 (Gray8Color g') =
-  let mapping = (\v -> v/255.0) . fromIntegral . xtermMapGray8bitComponent . (\v -> clamp v 0 23) :: Word8 -> Float
-      g = mapping g'
-  in  SRGBLin.rgb g g g
+-- in srgb colorspace (we divide by 255 to express the value as a
+-- floating point in range [0 1]).
+xterm256ToSRGB :: Xterm256Color -> Colour Float
+xterm256ToSRGB (SystemColor intensity color)
+  = fromJust $ lookup (intensity, color) aNSIColors
+xterm256ToSRGB (RGBColor (RGB r' g' b')) = sRGB r g b
+ where
+  mapping :: Word8 -> Float
+  mapping = (/ 255.0) . fromIntegral . xtermMapRGB8bitComponent . (\v -> clamp v 0 5)
+  r = mapping r'
+  g = mapping g'
+  b = mapping b'
+xterm256ToSRGB (GrayColor y') = sRGB y y y
+ where
+  mapping :: Word8 -> Float
+  mapping = (/ 255.0) . fromIntegral . xtermMapGray8bitComponent . (\v -> clamp v 0 23)
+  y = mapping y'
 
 -- | how xterm interprets 8bit rgb colors (deduced from https://jonasjacek.github.io/colors/)
 xtermMapRGB8bitComponent :: Word8
                          -- ^ input values are in range [0..5]
-                         -- (the admissible range for rgb components of 8bit rgb ANSI colors, cf.
+                         -- (the admissible range for rgb components of 8 bit
+                         -- rgb ANSI colors, cf.
                          -- https://en.wikipedia.org/wiki/ANSI_escape_code#Colors)
                          -> Word8
                          -- ^ output is in range [0..255]
@@ -55,7 +64,8 @@ xtermMapRGB8bitComponent n = 55 + n * 40
 -- | how xterm interprets 8bit grayscale colors (deduced from https://jonasjacek.github.io/colors/)
 xtermMapGray8bitComponent :: Word8
                          -- ^ input values are in range [0..23]
-                         -- (the admissible range for gray component of 8bit grayscale ANSI colors, cf.
+                         -- (the admissible range for gray component of 8 bit
+                         -- grayscale ANSI colors, cf.
                          -- https://en.wikipedia.org/wiki/ANSI_escape_code#Colors)
                           -> Word8
                           -- ^ output is in range [0..255]
@@ -75,46 +85,85 @@ clamp n min_ max_
   | n > max_ = max_
   | otherwise = n
 
--- | a Color8Code represents the escape code for an 8-bit ANSI Color. It is in range [0..255].
--- The ranges of its values are : (from https://en.wikipedia.org/wiki/ANSI_escape_code#Colors)
+-- | a Color8Code represents the escape code for an 8-bit ANSI Color. It is in
+-- range [0..255]. The ranges of its values are:
+-- (from https://en.wikipedia.org/wiki/ANSI_escape_code#Colors)
 --
 -- 0x00-0x07:  standard colors (as in ESC [ 30–37 m)
 -- 0x08-0x0F:  high intensity colors (as in ESC [ 90–97 m)
--- 0x10-0xE7:  6 × 6 × 6 cube (216 colors): 16 + 36 × r + 6 × g + b (0 ≤ r, g, b ≤ 5)
+-- 0x10-0xE7:  6 × 6 × 6 cube (216 colors):
+--             16 + 36 × r + 6 × g + b (0 ≤ r, g, b ≤ 5)
 -- 0xE8-0xFF:  grayscale from black to white in 24 steps
 --
--- The colors described by the 2 first ranges (0x00-0x07 and 0x08-0x0F) match exactly with
--- the 4 bit ANSI colors represented by (ColorIntensity, Color).
--- The colors of the 3rd range (0x10-0xE7) are represented by RGB8Color, and the colors of the 4th range
--- are represented by Gray8Color.
-color8CodeToEither :: Color8Code
-                   -> Either (ColorIntensity, Color) Color8
-color8CodeToEither (Color8Code c)
-  | c < 16    = Left $ fst $ aNSIColors !! fromIntegral c   -- interpreted as a 4-bit ANSI color
-  | c < 232   = Right $ asRGB (c-16)          -- interpreted as 8-bit rgb
-  | otherwise = Right $ Gray8Color (c-232)    -- interpreted as 8-bit grayscale
+-- The colors described by the 2 first ranges (0x00-0x07 and 0x08-0x0F) match
+-- exactly with the 4 bit ANSI colors represented by (ColorIntensity, Color).
+-- The colors of the 3rd range (0x10-0xE7) are represented by RGB8Color, and the
+-- colors of the 4th range are represented by Gray8Color.
+color8CodeToXterm256 :: Color8Code -> Xterm256Color
+color8CodeToXterm256 (Color8Code c)
+  | c < 16    = SystemColor intensity color -- interpreted as a 4-bit ANSI color
+  | c < 232   = RGBColor $ asRGB (c - 16)   -- interpreted as 8-bit rgb
+  | otherwise = GrayColor (c - 232)         -- interpreted as 8-bit grayscale
  where
-  asRGB i = let -- we know that i = 36 × r + 6 × g + b and (0 ≤ r, g, b ≤ 5) (cf. comment on top)
-                -- so we can deduce the unique set of corresponding r g and b values:
+  (intensity, color) = fst $ aNSIColors !! fromIntegral c
+  asRGB i = let -- we know that i = 36 × r + 6 × g + b and (0 ≤ r, g, b ≤ 5)
+                -- (cf. comment on top) so we can deduce the unique set of
+                -- corresponding r g and b values:
                 r = quot i 36
-                g = quot (r - 36*i) 6
-                b = i - (6*g + 36*i)
-            in  RGB8Color r g b
+                g = quot (i - 36 * r) 6
+                b = i - (6 * g + 36 * r)
+            in  RGB r g b
 
--- | Finds the 4 bit color that is closest in srgb colorspace to a given 24-bit color
-closest4bitsANSIColor :: SRGB.Colour Float -> (ColorIntensity, Color)
-closest4bitsANSIColor color = fst $ minimumBy order aNSIColors
+-- | Color8 represents an 8-bit ANSI color. This function converts it to the
+-- corresponding code, defined by https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+--
+-- For safety the values of Color8 are clamped in their respective ranges.
+xterm256ColorToCode :: Xterm256Color -> Color8Code
+xterm256ColorToCode (SystemColor Dull color)
+  = Color8Code (fromIntegral $ colorToCode color)
+xterm256ColorToCode (SystemColor Vivid color)
+  = Color8Code (fromIntegral $ 8 + colorToCode color)
+-- 8-bit rgb colors are represented by code:
+-- 16 + 36 × r + 6 × g + b (0 ≤ r, g, b ≤ 5) (see link to spec above)
+xterm256ColorToCode (RGBColor (RGB r' g' b'))
+  = Color8Code (16 + 36 * r + 6 * g + b)
+  where
+    clamp' x = clamp x 0 5
+    r = clamp' r'
+    g = clamp' g'
+    b = clamp' b'
+-- 8-bit grayscale colors are represented by code: 232 + g (g in [0..23]) (see
+-- link to spec above)
+xterm256ColorToCode (GrayColor y) = Color8Code (232 + clamp y 0 23)
+
+-- | Finds the color in the xterm 256 color protocol that is closest in srgb
+-- colorspace to a given color in that colorspace
+closestXterm256Color :: Colour Float -> Xterm256Color
+closestXterm256Color = closestColor xtermColors
  where
-  SRGB.RGB r g b = SRGB.toSRGB color
+  xterm256colors = map (\c -> color8CodeToXterm256 (Color8Code c)) [0 .. 255]
+  xtermColors = map (\x -> (x, xterm256ToSRGB x)) xterm256colors
+
+-- | Finds the 4 bit color that is closest in srgb colorspace to a given color
+-- in that space
+closest4bitsANSIColor :: Colour Float -> (ColorIntensity, Color)
+closest4bitsANSIColor = closestColor aNSIColors
+
+-- | Finds the color that has the closest equivalent color in srgb colorspace to
+-- a given color in that space
+closestColor :: [(a, Colour Float)] -> Colour Float -> a
+closestColor colors color = fst $ minimumBy order colors
+ where
+  RGB r g b = toSRGB color
   order (_, c1) (_, c2) = compare (dist c1) (dist c2)
-  dist c = let SRGB.RGB r' g' b' = SRGB.toSRGB c
+  dist c = let RGB r' g' b' = toSRGB c
                dr = r' - r
                dg = g' - g
                db = b' - b
            in  dr * dr + dg * dg + db * db
 
 -- | Maps 4-bit ANSI colors to the equivalent constructors of SRGB.Colour
-aNSIColors :: [((ColorIntensity, Color), SRGB.Colour Float)]
+aNSIColors :: [((ColorIntensity, Color), Colour Float)]
 aNSIColors = [ ((Dull,  Black),   black)
              , ((Dull,  Blue),    navy)
              , ((Dull,  Green),   green)
@@ -131,3 +180,16 @@ aNSIColors = [ ((Dull,  Black),   black)
              , ((Vivid, Magenta), magenta)
              , ((Vivid, Yellow),  yellow)
              , ((Vivid, White),   white) ]
+
+-- | 'colorToCode' @color@ returns the 0-based index of the color (one of the
+-- eight colors in the standard).
+colorToCode :: Color -> Int
+colorToCode color = case color of
+  Black   -> 0
+  Red     -> 1
+  Green   -> 2
+  Yellow  -> 3
+  Blue    -> 4
+  Magenta -> 5
+  Cyan    -> 6
+  White   -> 7

--- a/ansi-terminal.cabal
+++ b/ansi-terminal.cabal
@@ -69,6 +69,7 @@ Executable ansi-terminal-example
 
         Other-Modules:          System.Console.ANSI
                                 System.Console.ANSI.Codes
+                                System.Console.ANSI.Color
                                 System.Console.ANSI.Types
                                 System.Console.ANSI.Unix
 


### PR DESCRIPTION
To explain:

In `Types`:

* `SetColor8Code ConsoleLayer Color8Code` becomes `SetPaletteColor ConsoleLayer Color8Code` and the only addition to `SGR`.

* `Color8` becomes `Xterm256Color` and now covers the whole of the xterm 256 colour protocol, with constructors `SystemColor`, `RGBColor` and `GrayColor`. `RGBColor` makes use of the existing `RGB a` type from the `colour` package (`RGB8Color` was doing much the same thing as `RGB Word8`).

In `Color`:

* `color8To24` becomes `xterm256ToSRGB` and covers the whole protocol (as for the type).

* `color8CodeToEither` becomes `color8CodeToXterm256` (and is no longer either-or but the three-fold constructors of `Xterm256Color`).

* `color8ToCode` (from module `Codes`) becomes `xterm256ColorToCode` (here).

* `closestXterm256Color` is added, allowing code in common with `closest4bitsANSIColor` to be hived out to helper function `closestColor`.

* `colorToCode` is moved down to this module (from `Codes`).

* the types from `Data.Colour` no longer need qualification, because there are no name clashes.

In `Codes`:

* `colorToCode` has been moved (as above)

* `color8CodeToCode` has been added (because `Color8Code` - the types of an index to a 256 colour palette - is now distinguished from `Xterm256Color` - the type of the specific xterm 256 colour protocol).

* I removed the `layerOffset` `where` because it was out of place with the simpler logic for the other `Foreground`\`Background` cases

In `Emulator`:

* `approximateColor8Code` no longer needs the safety check, now that `Color8Code` wraps a `Word8`.

Generally:

* as I was doing a lot of editing anyway, I reformatted a little to apply Johan Tibell (hindent) style - principally, lines no longer than 80 characters. I also updated a few of the comments.

It compiles on my Windows 10 PC, but I've not tested it on that PC (or on legacy Windows or on a unix-like OS).